### PR TITLE
Move deps around

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,2 @@
 source 'https://rubygems.org'
-
 gemspec
-
-gem 'rake'
-gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest
+  minitest (~> 5.8)
   nested_open_struct!
-  rake
+  rake (~> 10.4)
 
 BUNDLED WITH
    1.10.6

--- a/nested_open_struct.gemspec
+++ b/nested_open_struct.gemspec
@@ -6,7 +6,10 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/porras/nested_open_struct"
   s.summary     = "Thin wrapper around OpenStruct to make structs 'nested'"
   s.description = "Thin wrapper around OpenStruct to make structs 'nested'"
- 
+
   s.files        = Dir.glob("lib/**/*") + %w(LICENSE README.md)
   s.require_path = 'lib'
+
+  s.add_development_dependency 'minitest', '~> 5.8'
+  s.add_development_dependency 'rake',     '~> 10.4'
 end

--- a/test/nested_open_struct_test.rb
+++ b/test/nested_open_struct_test.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/pride'
 require File.join(File.dirname(__FILE__), '..', 'lib', 'nested_open_struct')
 
 class NestedOpenStructTest < Minitest::Test


### PR DESCRIPTION
This
- moves the dependencies to the gemspec (as `Gemfile` loads it already),
- pins them to their major versions (so Rake 11 / Minitest 6 won’t break them),
- makes the test runs a bit more colourful.
